### PR TITLE
Fix wrong path check in ImageLoaderMachO

### DIFF
--- a/src/ImageLoaderMachO.cpp
+++ b/src/ImageLoaderMachO.cpp
@@ -1122,7 +1122,7 @@ bool ImageLoaderMachO::needsAddedLibSystemDepency(unsigned int libCount, const m
 				// It is OK for OS dylibs (libSystem or libmath or Rosetta shims) to have no dependents
 				// but all other dylibs must depend on libSystem for initialization to initialize libSystem first
 				// <rdar://problem/6497528> rosetta circular dependency spew
-				isNonOSdylib = ( (strncmp(installPath, "/usr/lib/", 9) != 0) && (strncmp(installPath, "/usr/libexec/oah/Shims", 9) != 0) );
+				isNonOSdylib = ( (strncmp(installPath, "/usr/lib/", 9) != 0) && (strncmp(installPath, "/usr/libexec/oah/Shims", 22) != 0) );
 				}
 				break;
 		}


### PR DESCRIPTION
This PR fixes a bug in `strncmp(installPath, "/usr/libexec/oah/Shims", 9)` - the size argument passed seems to be copied from a previous call and results in an incorrect path check as here only the `"/usr/libe"` prefix will be checked.

Please note that with my proposed change any directory path that starts with `"/usr/libexec/oah/Shims"` will be matched so `"/usr/libexec/oah/ShimsSOMETHING"` would also do.

I am not aware of this codebase, so maybe there should be a `"/"` at the end of this path?